### PR TITLE
pigma: fix 0.1.9 install failure (remove stale extract_dir)

### DIFF
--- a/bucket/pigma.json
+++ b/bucket/pigma.json
@@ -7,7 +7,6 @@
     "hash": "0389b28d4db01229fee46f3eba3d0fa2d6623e351511201fe1b1ef4efb1e29e1",
     "bin": "pigma.exe",
     "checkver": "github",
-    "extract_dir": "pigma-x86_64-pc-windows-msvc",
     "autoupdate": {
         "url": "https://github.com/akirco/pigma/releases/download/v$version/pigma-x86_64-pc-windows-msvc.zip"
     }


### PR DESCRIPTION
## Problem
`scoop install pigma` fails at the extraction step for 0.1.9.

## Root cause
The 0.1.9 release zip ships `pigma.exe` at the archive root (no subfolder), but the manifest still sets `extract_dir: "pigma-x86_64-pc-windows-msvc"`, which no longer exists in the archive. Scoop then fails to robocopy the nonexistent folder:

```
C:\Scoop\apps\pigma\0.1.9\pigma-x86_64-pc-windows-msvc\ - not found
Could not find 'pigma-x86_64-pc-windows-msvc'! (error 16)
```

## Fix
Remove the stale `extract_dir` field so Scoop extracts the flat zip directly. Verified locally: `scoop install pigma` succeeds and the shim works.

## Suggestion
Please consider adding an install smoke-test to the bucket CI to catch archive layout changes like this one.